### PR TITLE
Support for WebValve in any environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,16 @@ Check out [the Rails at Scale talk](https://www.youtube.com/watch?v=Nd9hnffxCP8)
 
 ## Getting Started
 
+WebValve is designed to work with Rails 4+.
+
 ### Installation
 
+You can add WebValve to your Gemfile with:
 ```
-gem install webvalve
+gem 'webvalve'
 ```
+
+Then run `bundle install`.
 
 ### Network connections disabled by default
 
@@ -187,6 +192,15 @@ The definition of `FakeService` is really simple. It's just a
 `Sinatra::Base` class. It is wired up to support returning JSON 
 responses and it will raise when a route is requested but it is 
 not registered.
+
+## Frequently Asked Questions
+
+> Can I use WebValve in environments like staging and demo?
+
+Yes! By default WebValve is only enabled in test and development
+environments; however, it can be enabled in other environments by
+setting `WEBVALVE_ENABLED=true`. This can be useful for spinning up
+cheap, one-off environments for user-testing or demos.
 
 ## How to Contribute
 

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -7,7 +7,8 @@ module WebValve
   autoload :FakeServiceConfig, 'webvalve/fake_service_config'
   autoload :Manager, 'webvalve/manager'
 
-  ENABLED_ENVS = %w(development test).freeze
+  ALWAYS_ENABLED_ENVS = %w(development test).freeze
+  ENABLED_VALUES = %w(1 t true).freeze
 
   class << self
     # @!method setup
@@ -21,7 +22,8 @@ module WebValve
     delegate :setup, :register, :whitelist_url, :reset, to: :manager
 
     def enabled?
-      Rails.env.in?(ENABLED_ENVS)
+      Rails.env.in?(ALWAYS_ENABLED_ENVS) ||
+        ENABLED_VALUES.include?(ENV['WEBVALVE_ENABLED'])
     end
 
     def config_paths

--- a/lib/webvalve/fake_service_config.rb
+++ b/lib/webvalve/fake_service_config.rb
@@ -1,7 +1,5 @@
 module WebValve
   class FakeServiceConfig
-    ENABLED_VALUES = %w(1 t true)
-
     attr_reader :service
 
     def initialize(service:, url: nil)
@@ -39,7 +37,7 @@ module WebValve
     end
 
     def service_enabled_in_env?
-      ENABLED_VALUES.include?(ENV["#{service_name.to_s.upcase}_ENABLED"])
+      WebValve::ENABLED_VALUES.include?(ENV["#{service_name.to_s.upcase}_ENABLED"])
     end
 
     def default_service_url

--- a/lib/webvalve/fake_service_config.rb
+++ b/lib/webvalve/fake_service_config.rb
@@ -8,7 +8,7 @@ module WebValve
     end
 
     def should_intercept?
-      Rails.env.test? ||
+      Rails.env.test? || # always intercept in test
         (WebValve.enabled? && !service_enabled_in_env?)
     end
 

--- a/spec/webvalve/fake_service_config_spec.rb
+++ b/spec/webvalve/fake_service_config_spec.rb
@@ -106,6 +106,28 @@ RSpec.describe WebValve::FakeServiceConfig do
           expect(subject.should_intercept?).to eq false
         end
       end
+
+      context 'when WEBVALVE_ENABLED is true' do
+        around do |ex|
+          with_env 'WEBVALVE_ENABLED' => '1' do
+            ex.run
+          end
+        end
+
+        it 'returns true' do
+          expect(subject.should_intercept?).to eq true
+        end
+
+        it 'respects DUMMY_ENABLED flag' do
+          with_env 'DUMMY_ENABLED' => '1' do
+            expect(subject.should_intercept?).to eq false
+          end
+
+          with_env 'DUMMY_ENABLED' => '0' do
+            expect(subject.should_intercept?).to eq true
+          end
+        end
+      end
     end
   end
 

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe WebValve::Manager do
   describe '#whitelist_url' do
     it 'raises on duplicates' do
       subject.whitelist_url "foo"
-      expect { subject.whitelist_url "foo" }.to raise_error /already registered/
+      expect { subject.whitelist_url "foo" }.to raise_error(/already registered/)
       expect(subject.whitelisted_urls.count).to eq 1
       expect(subject.whitelisted_urls).to contain_exactly(/foo/)
     end
@@ -22,7 +22,7 @@ RSpec.describe WebValve::Manager do
       fake = class_double(WebValve::FakeService)
 
       subject.register fake
-      expect { subject.register fake }.to raise_error /already registered/
+      expect { subject.register fake }.to raise_error(/already registered/)
       expect(subject.fake_service_configs.count).to eq 1
       expect(subject.fake_service_configs.first.service).to eq fake
     end


### PR DESCRIPTION
/domain @Betterment/webvalve-core 
/no-platform

I've been meaning to upgrade WebValve to support this behavior for a long time. This changeset includes the ability to enabled WebValve in non-local environments by setting `WEBVALVE_ENABLED=true` in the environment; this will establish the same "all non-whitelisted network interactions disabled" behavior as in development.