### PR TITLE
Fix Railtie / Rails initializers

### DIFF
--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -37,7 +37,7 @@ module WebValve
 
     def logger
       if defined?(::Rails)
-        ::Rails.logger | default_logger
+        ::Rails.logger || default_logger
       else
         default_logger
       end

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -16,6 +16,7 @@ module WebValve
     # @!method reset
     #   @see WebValve::Manager#reset
     delegate :setup, :register, :whitelist_url, :reset, to: :manager
+    attr_writer :logger
 
     def enabled?
       if env.in?(ALWAYS_ENABLED_ENVS)
@@ -36,21 +37,23 @@ module WebValve
     end
 
     def logger
-      if defined?(::Rails)
-        ::Rails.logger || default_logger
-      else
-        default_logger
-      end
+      @logger ||=
+        if defined?(::Rails)
+          # Rails.logger can be nil
+          ::Rails.logger || default_logger
+        else
+          default_logger
+        end
     end
 
     def default_logger
-      @logger ||= ActiveSupport::Logger.new(STDOUT).tap do |l|
+      ActiveSupport::Logger.new(STDOUT).tap do |l|
         l.formatter = ::Logger::Formatter.new
       end
     end
 
     if defined?(::Rails)
-      delegate :env, :env=, :logger=, to: ::Rails
+      delegate :env, :env=, to: ::Rails
     else
       def env
         @env ||= (ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development').inquiry
@@ -58,10 +61,6 @@ module WebValve
 
       def env=(env)
         @env = env&.inquiry
-      end
-
-      def logger=(logger)
-        @logger = logger
       end
     end
 

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -20,7 +20,7 @@ module WebValve
     def enabled?
       if env.in?(ALWAYS_ENABLED_ENVS)
         if ENV.key? 'WEBVALVE_ENABLED'
-          logger.warn(<<~MESSAGE)
+          logger&.warn(<<~MESSAGE)
             WARNING: Ignoring WEBVALVE_ENABLED environment variable setting (#{ENV['WEBVALVE_ENABLED']})
             WebValve is always enabled in development and test environments.
           MESSAGE

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -44,7 +44,7 @@ module WebValve
     end
 
     def default_logger
-      @default_logger ||= ActiveSupport::Logger.new(STDOUT).tap do |l|
+      @logger ||= ActiveSupport::Logger.new(STDOUT).tap do |l|
         l.formatter = ::Logger::Formatter.new
       end
     end

--- a/lib/webvalve/railtie.rb
+++ b/lib/webvalve/railtie.rb
@@ -1,15 +1,15 @@
 module WebValve
   class Railtie < ::Rails::Railtie
-    if WebValve.enabled?
-      initializer 'webvalve.set_autoload_paths', before: :set_autoload_paths do |app|
-        WebValve.config_paths << app.root
+    initializer 'webvalve.set_autoload_paths', before: :set_autoload_paths do |app|
+      WebValve.config_paths << app.root
 
-        WebValve.config_paths.each do |root|
-          app.config.eager_load_paths << root.join('webvalve').to_s
-        end
+      WebValve.config_paths.each do |root|
+        app.config.eager_load_paths << root.join('webvalve').to_s
       end
+    end
 
-      initializer 'webvalve.setup' do
+    initializer 'webvalve.setup' do
+      if WebValve.enabled?
         WebValve.config_paths.each do |root|
           path = root.join('config', 'webvalve.rb').to_s
           load path if File.exist?(path)

--- a/lib/webvalve/railtie.rb
+++ b/lib/webvalve/railtie.rb
@@ -1,6 +1,7 @@
 module WebValve
   class Railtie < ::Rails::Railtie
     initializer 'webvalve.set_autoload_paths', before: :set_autoload_paths do |app|
+      return unless WebValve.enabled?
       WebValve.config_paths << app.root
 
       WebValve.config_paths.each do |root|
@@ -9,15 +10,14 @@ module WebValve
     end
 
     initializer 'webvalve.setup' do
-      if WebValve.enabled?
-        WebValve.config_paths.each do |root|
-          path = root.join('config', 'webvalve.rb').to_s
-          load path if File.exist?(path)
-        end
+      return unless WebValve.enabled?
+      WebValve.config_paths.each do |root|
+        path = root.join('config', 'webvalve.rb').to_s
+        load path if File.exist?(path)
+      end
 
-        config.after_initialize do
-          WebValve.setup
-        end
+      config.after_initialize do
+        WebValve.setup
       end
     end
   end

--- a/lib/webvalve/railtie.rb
+++ b/lib/webvalve/railtie.rb
@@ -1,23 +1,25 @@
 module WebValve
   class Railtie < ::Rails::Railtie
     initializer 'webvalve.set_autoload_paths', before: :set_autoload_paths do |app|
-      return unless WebValve.enabled?
-      WebValve.config_paths << app.root
+      if WebValve.enabled?
+        WebValve.config_paths << app.root
 
-      WebValve.config_paths.each do |root|
-        app.config.eager_load_paths << root.join('webvalve').to_s
+        WebValve.config_paths.each do |root|
+          app.config.eager_load_paths << root.join('webvalve').to_s
+        end
       end
     end
 
     initializer 'webvalve.setup' do
-      return unless WebValve.enabled?
-      WebValve.config_paths.each do |root|
-        path = root.join('config', 'webvalve.rb').to_s
-        load path if File.exist?(path)
-      end
+      if WebValve.enabled?
+        WebValve.config_paths.each do |root|
+          path = root.join('config', 'webvalve.rb').to_s
+          load path if File.exist?(path)
+        end
 
-      config.after_initialize do
-        WebValve.setup
+        config.after_initialize do
+          WebValve.setup
+        end
       end
     end
   end


### PR DESCRIPTION
Hello! First of all thanks for this gem.
I've noticed a problem with the Railtie initializers.

`WebValve.enabled?` is called inside the `Railtie` class. The problem with this is that user defined environment variables such as `WEBVALVE_ENABLED` might not be set when this class is loaded. This is true for users of Figaro or users who dynamically set env vars in an initializer or config file. So the call to  `enabled?` should be inside the initializers.

Moreover `Rails.logger` (which might be used in `enabled?` is not initialized at this point. It is actually not initialized when `webvalve.set_autoload_paths` runs. To solve this I added the safe navigation operator in  `enabled?`.