### PR TITLE
Enabled whitelist for all environments

### DIFF
--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -50,7 +50,7 @@ module WebValve
 
     def webmock_disable_options
       { allow_localhost: true }.tap do |opts|
-        opts[:allow] = whitelisted_url_regexps unless WebValve.env.test?
+        opts[:allow] = whitelisted_url_regexps
       end
     end
 


### PR DESCRIPTION
Enabled Webvale.whitelist_url work in all environments including test environment