### PR TITLE
rename `whitelist_url` to `allow_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Added
 ### Removed
 
+## [0.9.10] - 2019-09-09
+### Changed
+- rename `whitelist_url` to `allow_url` (https://github.com/Betterment/retail/pull/4424)
+
 ## [0.9.9] - 2019-05-24
 ### Changed
 - fix integration with `webdrivers` gem so Rails 6 should work out of the box (https://github.com/Betterment/webvalve/pull/32)
@@ -31,6 +35,7 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 - WebMock 3+ support from @messanjah (https://github.com/Betterment/webvalve/pull/22)
 
 [Unreleased]: https://github.com/Betterment/webvalve/compare/v0.9.9...HEAD
+[0.9.10]: https://github.com/Betterment/webvalve/compare/v0.9.9...v0.9.10
 [0.9.9]: https://github.com/Betterment/webvalve/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/Betterment/webvalve/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/Betterment/webvalve/compare/v0.9.6...v0.9.7

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ This will drop a new file in your config directory.
 # WebValve.register FakeBank
 # WebValve.register FakeExample, url: 'https://api.example.org'
 #
-# # whitelist urls
+# # add urls to allowlist
 #
-# WebValve.whitelist_url 'https://example.com'
+# WebValve.add_url_to_allowlist 'https://example.com'
 ```
 
 If you're not using Rails, you can create this file for yourself.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This will drop a new file in your config directory.
 #
 # # add urls to allowlist
 #
-# WebValve.add_url_to_allowlist 'https://example.com'
+# WebValve.allowlist_url 'https://example.com'
 ```
 
 If you're not using Rails, you can create this file for yourself.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This will drop a new file in your config directory.
 #
 # # add urls to allowlist
 #
-# WebValve.allowlist_url 'https://example.com'
+# WebValve.allow_url 'https://example.com'
 ```
 
 If you're not using Rails, you can create this file for yourself.

--- a/lib/generators/webvalve/install_generator.rb
+++ b/lib/generators/webvalve/install_generator.rb
@@ -19,9 +19,9 @@ module Webvalve
           # WebValve.register FakeThing
           # WebValve.register FakeExample, url: 'https://api.example.org'
           #
-          # # whitelist urls
+          # # add urls to the allowlist
           #
-          # WebValve.whitelist_url 'https://example.com'
+          # WebValve.add_url_to_allowlist 'https://example.com'
         FILE
       end
 

--- a/lib/generators/webvalve/install_generator.rb
+++ b/lib/generators/webvalve/install_generator.rb
@@ -21,7 +21,7 @@ module Webvalve
           #
           # # add urls to the allowlist
           #
-          # WebValve.add_url_to_allowlist 'https://example.com'
+          # WebValve.allowlist_url 'https://example.com'
         FILE
       end
 

--- a/lib/generators/webvalve/install_generator.rb
+++ b/lib/generators/webvalve/install_generator.rb
@@ -21,7 +21,7 @@ module Webvalve
           #
           # # add urls to the allowlist
           #
-          # WebValve.allowlist_url 'https://example.com'
+          # WebValve.allow_url 'https://example.com'
         FILE
       end
 

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -11,11 +11,11 @@ module WebValve
     #   @see WebValve::Manager#setup
     # @!method register
     #   @see WebValve::Manager#register
-    # @!method whitelist_url
-    #   @see WebValve::Manager#whitelist_url
+    # @!method add_url_to_allowlist
+    #   @see WebValve::Manager#add_url_to_allowlist
     # @!method reset
     #   @see WebValve::Manager#reset
-    delegate :setup, :register, :whitelist_url, :reset, to: :manager
+    delegate :setup, :register, :add_url_to_allowlist, :reset, to: :manager
     attr_writer :logger
 
     def enabled?

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -11,11 +11,11 @@ module WebValve
     #   @see WebValve::Manager#setup
     # @!method register
     #   @see WebValve::Manager#register
-    # @!method add_url_to_allowlist
-    #   @see WebValve::Manager#add_url_to_allowlist
+    # @!method allowlist_url
+    #   @see WebValve::Manager#allowlist_url
     # @!method reset
     #   @see WebValve::Manager#reset
-    delegate :setup, :register, :add_url_to_allowlist, :reset, to: :manager
+    delegate :setup, :register, :allowlist_url, :reset, to: :manager
     attr_writer :logger
 
     def enabled?

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -11,11 +11,11 @@ module WebValve
     #   @see WebValve::Manager#setup
     # @!method register
     #   @see WebValve::Manager#register
-    # @!method allowlist_url
-    #   @see WebValve::Manager#allowlist_url
+    # @!method allow_url
+    #   @see WebValve::Manager#allow_url
     # @!method reset
     #   @see WebValve::Manager#reset
-    delegate :setup, :register, :allowlist_url, :reset, to: :manager
+    delegate :setup, :register, :allow_url, :reset, to: :manager
     attr_writer :logger
 
     def enabled?

--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -12,9 +12,9 @@ module WebValve
       fake_service_configs << FakeServiceConfig.new(service: fake_service, **args)
     end
 
-    def whitelist_url(url)
-      raise "#{url} already registered" if whitelisted_urls.include?(url)
-      whitelisted_urls << url
+    def add_url_to_allowlist(url)
+      raise "#{url} already registered" if allowlisted_urls.include?(url)
+      allowlisted_urls << url
     end
 
     def setup
@@ -22,7 +22,7 @@ module WebValve
         if config.should_intercept?
           webmock_service config
         else
-          whitelist_service config
+          allowlist_service config
         end
       end
 
@@ -32,7 +32,7 @@ module WebValve
 
     # @api private
     def reset
-      whitelisted_urls.clear
+      allowlisted_urls.clear
       fake_service_configs.clear
     end
 
@@ -42,20 +42,20 @@ module WebValve
     end
 
     # @api private
-    def whitelisted_urls
-      @whitelisted_urls ||= Set.new
+    def allowlisted_urls
+      @allowlisted_urls ||= Set.new
     end
 
     private
 
     def webmock_disable_options
       { allow_localhost: true }.tap do |opts|
-        opts[:allow] = whitelisted_url_regexps unless WebValve.env.test?
+        opts[:allow] = allowlisted_url_regexps unless WebValve.env.test?
       end
     end
 
-    def whitelisted_url_regexps
-      whitelisted_urls.map { |url| url_to_regexp url }
+    def allowlisted_url_regexps
+      allowlisted_urls.map { |url| url_to_regexp url }
     end
 
     def webmock_service(config)
@@ -65,8 +65,8 @@ module WebValve
       ).to_rack(FakeServiceWrapper.new(config.service))
     end
 
-    def whitelist_service(config)
-      whitelisted_urls << config.service_url
+    def allowlist_service(config)
+      allowlisted_urls << config.service_url
     end
 
     def url_to_regexp(url)

--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -12,7 +12,7 @@ module WebValve
       fake_service_configs << FakeServiceConfig.new(service: fake_service, **args)
     end
 
-    def add_url_to_allowlist(url)
+    def allowlist_url(url)
       raise "#{url} already registered" if allowlisted_urls.include?(url)
       allowlisted_urls << url
     end

--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -12,7 +12,7 @@ module WebValve
       fake_service_configs << FakeServiceConfig.new(service: fake_service, **args)
     end
 
-    def allowlist_url(url)
+    def allow_url(url)
       raise "#{url} already registered" if allowlisted_urls.include?(url)
       allowlisted_urls << url
     end

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe WebValve::Manager do
     described_class.is_a? Singleton
   end
 
-  describe '#whitelist_url' do
+  describe '#add_url_to_allowlist' do
     it 'raises on duplicates' do
-      subject.whitelist_url "foo"
-      expect { subject.whitelist_url "foo" }.to raise_error(/already registered/)
-      expect(subject.whitelisted_urls.count).to eq 1
-      expect(subject.whitelisted_urls).to contain_exactly(/foo/)
+      subject.add_url_to_allowlist "foo"
+      expect { subject.add_url_to_allowlist "foo" }.to raise_error(/already registered/)
+      expect(subject.allowlisted_urls.count).to eq 1
+      expect(subject.allowlisted_urls).to contain_exactly(/foo/)
     end
   end
 
@@ -69,12 +69,12 @@ RSpec.describe WebValve::Manager do
         end
       end
 
-      it 'does not whitelist configured urls in webmock' do
+      it 'does not allowlist configured urls in webmock' do
         allow(WebMock).to receive(:disable_net_connect!)
         results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
 
-        subject.whitelist_url 'http://foo.dev'
-        subject.whitelist_url 'http://bar.dev'
+        subject.add_url_to_allowlist 'http://foo.dev'
+        subject.add_url_to_allowlist 'http://bar.dev'
 
         subject.setup
 
@@ -90,12 +90,12 @@ RSpec.describe WebValve::Manager do
         end
       end
 
-      it 'whitelists configured urls in webmock' do
+      it 'allowlists configured urls in webmock' do
         allow(WebMock).to receive(:disable_net_connect!)
         results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
 
-        subject.whitelist_url 'http://foo.dev'
-        subject.whitelist_url 'http://bar.dev'
+        subject.add_url_to_allowlist 'http://foo.dev'
+        subject.add_url_to_allowlist 'http://bar.dev'
 
         subject.setup
 
@@ -117,7 +117,7 @@ RSpec.describe WebValve::Manager do
         expect(web_mock_stubble).to have_received(:to_rack)
       end
 
-      it 'whitelists registered fakes that are enabled in ENV' do
+      it 'allowlists registered fakes that are enabled in ENV' do
         enabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
 
         with_env 'SOMETHING_ENABLED' => '1', 'SOMETHING_API_URL' => 'http://real.dev' do
@@ -125,7 +125,7 @@ RSpec.describe WebValve::Manager do
           subject.setup
         end
 
-        expect(subject.whitelisted_urls).to include 'http://real.dev'
+        expect(subject.allowlisted_urls).to include 'http://real.dev'
       end
     end
   end

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe WebValve::Manager do
     described_class.is_a? Singleton
   end
 
-  describe '#allowlist_url' do
+  describe '#allow_url' do
     it 'raises on duplicates' do
-      subject.allowlist_url "foo"
-      expect { subject.allowlist_url "foo" }.to raise_error(/already registered/)
+      subject.allow_url "foo"
+      expect { subject.allow_url "foo" }.to raise_error(/already registered/)
       expect(subject.allowlisted_urls.count).to eq 1
       expect(subject.allowlisted_urls).to contain_exactly(/foo/)
     end
@@ -73,8 +73,8 @@ RSpec.describe WebValve::Manager do
         allow(WebMock).to receive(:disable_net_connect!)
         results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
 
-        subject.allowlist_url 'http://foo.dev'
-        subject.allowlist_url 'http://bar.dev'
+        subject.allow_url 'http://foo.dev'
+        subject.allow_url 'http://bar.dev'
 
         subject.setup
 
@@ -94,8 +94,8 @@ RSpec.describe WebValve::Manager do
         allow(WebMock).to receive(:disable_net_connect!)
         results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
 
-        subject.allowlist_url 'http://foo.dev'
-        subject.allowlist_url 'http://bar.dev'
+        subject.allow_url 'http://foo.dev'
+        subject.allow_url 'http://bar.dev'
 
         subject.setup
 

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe WebValve::Manager do
     described_class.is_a? Singleton
   end
 
-  describe '#add_url_to_allowlist' do
+  describe '#allowlist_url' do
     it 'raises on duplicates' do
-      subject.add_url_to_allowlist "foo"
-      expect { subject.add_url_to_allowlist "foo" }.to raise_error(/already registered/)
+      subject.allowlist_url "foo"
+      expect { subject.allowlist_url "foo" }.to raise_error(/already registered/)
       expect(subject.allowlisted_urls.count).to eq 1
       expect(subject.allowlisted_urls).to contain_exactly(/foo/)
     end
@@ -73,8 +73,8 @@ RSpec.describe WebValve::Manager do
         allow(WebMock).to receive(:disable_net_connect!)
         results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
 
-        subject.add_url_to_allowlist 'http://foo.dev'
-        subject.add_url_to_allowlist 'http://bar.dev'
+        subject.allowlist_url 'http://foo.dev'
+        subject.allowlist_url 'http://bar.dev'
 
         subject.setup
 
@@ -94,8 +94,8 @@ RSpec.describe WebValve::Manager do
         allow(WebMock).to receive(:disable_net_connect!)
         results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
 
-        subject.add_url_to_allowlist 'http://foo.dev'
-        subject.add_url_to_allowlist 'http://bar.dev'
+        subject.allowlist_url 'http://foo.dev'
+        subject.allowlist_url 'http://bar.dev'
 
         subject.setup
 

--- a/spec/webvalve_spec.rb
+++ b/spec/webvalve_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe WebValve do
     expect(described_class).to respond_to(:reset)
   end
 
-  it 'delegates .whitelist_url to manager' do
-    expect(described_class).to respond_to(:whitelist_url)
+  it 'delegates .add_url_to_allowlist to manager' do
+    expect(described_class).to respond_to(:add_url_to_allowlist)
   end
 end

--- a/spec/webvalve_spec.rb
+++ b/spec/webvalve_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe WebValve do
     expect(described_class).to respond_to(:reset)
   end
 
-  it 'delegates .allowlist_url to manager' do
-    expect(described_class).to respond_to(:allowlist_url)
+  it 'delegates .allow_url to manager' do
+    expect(described_class).to respond_to(:allow_url)
   end
 end

--- a/spec/webvalve_spec.rb
+++ b/spec/webvalve_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe WebValve do
     expect(described_class).to respond_to(:reset)
   end
 
-  it 'delegates .add_url_to_allowlist to manager' do
-    expect(described_class).to respond_to(:add_url_to_allowlist)
+  it 'delegates .allowlist_url to manager' do
+    expect(described_class).to respond_to(:allowlist_url)
   end
 end


### PR DESCRIPTION
i think this is maybe the last change before creating a 1.0.0. 

we've been in production with this library for a few years and we've pushed it pretty hard.

/domain @smudge @jmileham 
/no-platform

i'm making this as a breaking change because we're not at 1.0.0 yet and it's a straightforward upgrade