### PR TITLE
support enabling webvalve in non-local, production-like envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - rework configuration so that WebValve has 3 operating modes: off,
     on+allowing, and on+intercepting. support toggling the latter two
-    modes with `WEBVALVED_ENABLED=1` and `WEBVALVED_ENABLED=0`. (https://github.com/Betterment/webvalve/pull/34)
+    modes with
+    `WEBVALVED_ENABLED=1`+`WEBVALVE_SERVICE_ENABLED_DEFAULT=1` and
+    `WEBVALVED_ENABLED=1`+`WEBVALVE_SERVICE_ENABLED_DEFAULT=0`.
+    (https://github.com/Betterment/webvalve/pull/34)
 
 ## [0.10.0] - 2019-09-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Added
 ### Removed
 
+## [0.11.0] - 2019-09-23
+### Changed
+- rework configuration so that WebValve has 3 operating modes: off,
+    on+allowing, and on+intercepting. support toggling the latter two
+    modes with `WEBVALVED_ENABLED=1` and `WEBVALVED_ENABLED=0`. (https://github.com/Betterment/webvalve/pull/34)
+
 ## [0.10.0] - 2019-09-23
 ### Changed
 - `Webvalve.register` no longer accepts classes; you must provide class names as strings. Fixes a Rails 6 deprecation warning. (https://github.com/Betterment/webvalve/pull/35)

--- a/README.md
+++ b/README.md
@@ -232,7 +232,10 @@ not registered.
 Yes! By default WebValve is only enabled in test and development
 environments; however, it can be enabled in other environments by
 setting `WEBVALVE_ENABLED=true`. This can be useful for spinning up
-cheap, one-off environments for user-testing or demos.
+cheap, one-off environments for user-testing or demos. When WebValve is
+enabled in any environment other than development/test it will default
+services to enabled rather than disabled. This ensures that
+production-like environments are run integrated by default.
 
 > Can I use WebValve without Rails?
 

--- a/README.md
+++ b/README.md
@@ -30,22 +30,6 @@ gem 'webvalve'
 
 Then run `bundle install`.
 
-WebValve has 3 modes of operation
-* intercepting - traffic associated with fakes is routed through
-    fakes. all other traffic (except allowed urls) is blocked.
-    SOME_SERVICE_ENABLED=1 can be used to disable faking for that
-    specific service.
-* allowing - all traffic is allowed. individual services can be
-    routed through fakes by setting SOME_SERVICE_ENABLED=0
-* disabled - traffic is not tampered with.
-
-* in `test` environments, it's always enabled and intercepting
-* in `development` environments, it's always enabled and intercepting,
-    but services can be toggled on for real
-* in production-like environments, it defaults to disabled, but it can
-    be switched into enabled+intercepting with WEBVALVE_ENABLED=1 or
-    enabled+allowing with WEBVALVE_ENABLED=0
-
 ### Network connections disabled by default
 
 The default mode in development and test is to disallow all HTTP network

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ gem 'webvalve'
 
 Then run `bundle install`.
 
+WebValve has 3 modes of operation
+* enabled+intercepting - traffic associated with fakes is routed through
+    fakes. all other traffic (except allowed urls) is blocked.
+    SOME_SERVICE_ENABLED=1 can be used to disable faking for that
+    specific service.
+* enabled+allowing - all traffic is allowed. individual services can be
+    routed through fakes by setting SOME_SERVICE_ENABLED=0
+* disabled - traffic is not tampered with.
+
+* in `test` environments, it's always enabled and intercepting
+* in `development` environments, it's always enabled and intercepting,
+    but services can be toggled on for real
+* in production-like environments, it defaults to disabled, but it can
+    be switched into enabled+intercepting with WEBVALVE_ENABLED=1 or
+    enabled+allowing with WEBVALVE_ENABLED=0
+
 ### Network connections disabled by default
 
 The default mode in development and test is to disallow all HTTP network

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ gem 'webvalve'
 Then run `bundle install`.
 
 WebValve has 3 modes of operation
-* enabled+intercepting - traffic associated with fakes is routed through
+* intercepting - traffic associated with fakes is routed through
     fakes. all other traffic (except allowed urls) is blocked.
     SOME_SERVICE_ENABLED=1 can be used to disable faking for that
     specific service.
-* enabled+allowing - all traffic is allowed. individual services can be
+* allowing - all traffic is allowed. individual services can be
     routed through fakes by setting SOME_SERVICE_ENABLED=0
 * disabled - traffic is not tampered with.
 

--- a/README.md
+++ b/README.md
@@ -243,15 +243,22 @@ not registered.
 
 ## Frequently Asked Questions
 
-> Can I use WebValve in environments like staging and demo?
+> Can I use WebValve in environments like staging, demo, and production?
 
 Yes! By default WebValve is only enabled in test and development
 environments; however, it can be enabled in other environments by
-setting `WEBVALVE_ENABLED=true`. This can be useful for spinning up
-cheap, one-off environments for user-testing or demos. When WebValve is
-enabled in any environment other than development/test it will default
-services to enabled rather than disabled. This ensures that
-production-like environments are run integrated by default.
+setting `WEBVALVE_ENABLED=true` (actually, any of 1/t/true will work).
+This can be useful for spinning up cheap, one-off environments for
+user-testing or demos. When WebValve is enabled in any environment other
+than development/test it will default services to enabled rather than
+disabled, allowing all traffic to pass-thru. This ensures that
+production-like environments are run integrated by default. You can
+change this behavior by setting `WEBVALVE_SERVICE_ENABLED_DEFAULT=false`
+(any of 0/f/false will work). This will default to the same experience
+as local development, defaulting services to disabled, intercepting all
+traffic. In either of these modes, you can use the
+`$SERVICE_ENABLED=true/false` to toggle a specific service into the
+desired state.
 
 > Can I use WebValve without Rails?
 

--- a/design/adr-001.md
+++ b/design/adr-001.md
@@ -1,0 +1,87 @@
+# ADR 001: Use ENV variable to control behavior in production-like envs
+
+## Status
+
+Proposed
+
+## Context
+
+We would like to be able to use WebValve to fake external service
+integrations in production-like environments.
+
+When using WebValve in a production-like environment, we'd like to be
+able to support three different use-cases:
+* enable all services by default, and don't load WebValve at all. This
+    is equivalent to WebValve's current production behavior:
+    zero-overhead, no risk of accidentally loading a fake service
+    instead of a real one.
+* enable all services by default (as if WebValve is disabled) but allow
+    each service to be flipped into faking mode based on an env
+    variable. This allows us to support faking a service in a staging
+    environment where we cannot actually integrate with a real or
+    sandbox version of the external service while still connecting to
+    real versions of all other services.
+* disable all services by default (as if WebValve is enabled) but allow
+    each service to be flipped into real mode bsed on an env variable.
+    This allows us to spin up cheap one-off environments for
+    user-testing, proof-of-concepting, etc.
+
+In summary, we need ways to control:
+* the activation of WebValve: loading the library, loading
+    the fakes, configuring WebMock
+* the default mode of WebValve: intercepting vs. allowing
+    (pass-through)
+* the explicit enabling / disabling of individual services
+
+We came up with a few approaches to support these use-cases:
+
+*Activate if required*
+This will load and activate WebValve when it's required. If you don't
+want to activate it, don't require it. The downside to this approach is
+it's easy to accidentally load WebValve in the wrong env. Additionally,
+in an env where we want to enable all services by default and only
+disable select ones, we'd have to define the ${SERVICE}_ENABLED env
+variable for all services and update each time we add a new services,
+which can be quite annoying.
+
+*Activate based on env variable*
+Rework the WEBVALVE_ENABLED env variable so that it supports 3 modes:
+off, on and allowing traffic by default, and on and intercepting traffic
+by default. If the WEBVALVE_ENABLED variable is unset, don't activate
+the lib. If WEBVALVE_ENABLED is explicitly set to 0 then load in
+passthru mode, allowing fakes to be toggled on explicitly via their
+${SERVICE}_ENABLED env variable. If WEBVALVE_ENABLED is explicitly set
+to 1 then load in intercepting mode, allowing fakes to be toggled off
+explicitly via their ${SERVICE}_ENABLED env variable.
+
+*Don't support it at all*
+Lastly, a sort of non-option option: don't support faking in
+production-like envs. Don't support any envs other than dev and test.
+Advise that the gem should only go in the dev/test group. This is safest
+for production use, but means that production-like envs that want to
+swap out real versions of services would have to do it by actually
+deploying a version of their fake service and connecting to it out of
+process as if it were a real service. This is nice from the "make it
+real" angle, but introduces quite a bit of overhead and it's
+well-aligned with the WebValve philosophy of making things convenient
+and as isolated as possible.
+
+## Decision
+
+We chose the "Activate based on env variable" approach. It introduces
+more complexity to this library, but support for these use-cases feels
+worth it. We're not the happiest with having the WEBVALVE_ENABLED env
+variable have different meanings for "0" and unset, but I think that we
+can document it clearly to head off confusion for the power users that
+actually want to utilize WebValve in production-like environments. For
+the standard user, nothing about how they're currently using WebValve
+will change.
+
+## Consequences
+
+More complexity to manage in this library.
+
+Controlling WebValve activation via an ENV variable, makes it slightly
+easier to unintentionally enable WebValve in production.
+
+The current behavior of WEBVALVE_ENABLED is replaced.

--- a/design/adr-001.md
+++ b/design/adr-001.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -22,7 +22,7 @@ able to support three different use-cases:
     sandbox version of the external service while still connecting to
     real versions of all other services.
 * disable all services by default (as if WebValve is enabled) but allow
-    each service to be flipped into real mode bsed on an env variable.
+    each service to be flipped into real mode based on an env variable.
     This allows us to spin up cheap one-off environments for
     user-testing, proof-of-concepting, etc.
 
@@ -44,15 +44,18 @@ disable select ones, we'd have to define the ${SERVICE}_ENABLED env
 variable for all services and update each time we add a new services,
 which can be quite annoying.
 
-*Activate based on env variable*
-Rework the WEBVALVE_ENABLED env variable so that it supports 3 modes:
-off, on and allowing traffic by default, and on and intercepting traffic
-by default. If the WEBVALVE_ENABLED variable is unset, don't activate
-the lib. If WEBVALVE_ENABLED is explicitly set to 0 then load in
-passthru mode, allowing fakes to be toggled on explicitly via their
-${SERVICE}_ENABLED env variable. If WEBVALVE_ENABLED is explicitly set
-to 1 then load in intercepting mode, allowing fakes to be toggled off
-explicitly via their ${SERVICE}_ENABLED env variable.
+*Activate based on env variables*
+Introduce a new WEBVALVE_SERVICE_ENABLED_DEFAULT env variable that
+controls the default service enabled behavior, or the "mode" webvalve
+runs in: on and allowing traffic by default, or on and intercepting
+traffic by default. If the WEBVALVE_ENABLED variable is unset, don't
+activate the lib. If WEBVALVE_ENABLED is set to truthy (1/t/true) and
+WEBVALVE_SERVICE_ENABLED_DEFAULT is unset then load in passthru mode,
+allowing fakes to be toggled on explicitly via their ${SERVICE}_ENABLED
+env variable. If WEBVALVE_ENABLED is explicitly set to to truthy and
+WEBVALVE_SERVICE_ENABLED_DEFAULT is set to falsey (0/f/false) then load
+in intercepting mode, allowing fakes to be toggled off explicitly via
+their ${SERVICE}_ENABLED env variable.
 
 *Don't support it at all*
 Lastly, a sort of non-option option: don't support faking in
@@ -68,14 +71,33 @@ and as isolated as possible.
 
 ## Decision
 
-We chose the "Activate based on env variable" approach. It introduces
+We chose the "Activate based on env variables" approach. It introduces
 more complexity to this library, but support for these use-cases feels
-worth it. We're not the happiest with having the WEBVALVE_ENABLED env
-variable have different meanings for "0" and unset, but I think that we
-can document it clearly to head off confusion for the power users that
-actually want to utilize WebValve in production-like environments. For
-the standard user, nothing about how they're currently using WebValve
-will change.
+worth it. We're not the happiest with having
+`WEBVALVE_SERVICE_ENABLED_DEFAULT` as an env variable name, but I think
+that we can document it clearly to head off confusion for the power
+users that actually want to utilize WebValve in production-like
+environments. For the standard user, nothing about how they're currently
+using WebValve will change.
+
+Here's a summary of the behavior based on environment.
+
+When the env is test/development
+* webvalve is enabled and always runs in intercepting mode where
+  services are intercepted by default
+
+When the env is NOT test/development, e.g. production
+* webvalve is disabled unless WEBVALVE_ENABLED=1/t/true
+* when WEBVALVE_ENABLED is truthy, webvalve is enabled in allowing mode
+  where all traffic is allowed by default
+* $SERVICE_ENABLED=0/f/false can be used to switch a service into intercepting
+  mode, i.e. enable the fake service
+* when WEBVALVE_ENABLED is truthy and
+  WEBVALVE_SERVICE_ENABLED_DEFAULT=0/f/false then webvalve is enabled in
+  intercepting mode where all traffic is intercepted by default
+* $SERVICE_ENABLED=1/t/true can be used to switch a service into
+  allowing mode, i.e. allow the traffic to that service to go through to
+  the internet
 
 ## Consequences
 
@@ -84,4 +106,5 @@ More complexity to manage in this library.
 Controlling WebValve activation via an ENV variable, makes it slightly
 easier to unintentionally enable WebValve in production.
 
-The current behavior of WEBVALVE_ENABLED is replaced.
+The current behavior of WEBVALVE_ENABLED in production is slightly
+altered: by default we will allow all traffic in production.

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -12,9 +12,9 @@ module WebValve
     #   @see WebValve::Manager#allow_url
     # @!method reset
     #   @see WebValve::Manager#reset
-    # @!method disabled?
-    #   @see WebValve::Manager#disabled?
-    delegate :setup, :register, :allow_url, :reset, :disabled?, to: :manager
+    # @!method enabled?
+    #   @see WebValve::Manager#enabled?
+    delegate :setup, :register, :allow_url, :reset, :enabled?, to: :manager
     attr_writer :logger
 
     def config_paths

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -12,7 +12,9 @@ module WebValve
     #   @see WebValve::Manager#allow_url
     # @!method reset
     #   @see WebValve::Manager#reset
-    delegate :setup, :register, :allow_url, :reset, to: :manager
+    # @!method disabled?
+    #   @see WebValve::Manager#disabled?
+    delegate :setup, :register, :allow_url, :reset, :disabled?, to: :manager
     attr_writer :logger
 
     def config_paths

--- a/lib/webvalve.rb
+++ b/lib/webvalve.rb
@@ -3,9 +3,6 @@ require 'active_support'
 require 'active_support/core_ext'
 
 module WebValve
-  ALWAYS_ENABLED_ENVS = %w(development test).freeze
-  ENABLED_VALUES = %w(1 t true).freeze
-
   class << self
     # @!method setup
     #   @see WebValve::Manager#setup
@@ -17,20 +14,6 @@ module WebValve
     #   @see WebValve::Manager#reset
     delegate :setup, :register, :allow_url, :reset, to: :manager
     attr_writer :logger
-
-    def enabled?
-      if env.in?(ALWAYS_ENABLED_ENVS)
-        if ENV.key? 'WEBVALVE_ENABLED'
-          logger.warn(<<~MESSAGE)
-            WARNING: Ignoring WEBVALVE_ENABLED environment variable setting (#{ENV['WEBVALVE_ENABLED']})
-            WebValve is always enabled in development and test environments.
-          MESSAGE
-        end
-        true
-      else
-        ENABLED_VALUES.include?(ENV['WEBVALVE_ENABLED'])
-      end
-    end
 
     def config_paths
       @config_paths ||= Set.new

--- a/lib/webvalve/fake_service_config.rb
+++ b/lib/webvalve/fake_service_config.rb
@@ -14,7 +14,7 @@ module WebValve
 
       if WebValve.env.development?
         # for local development we wanna default to all services disabled
-        # so that we get  nice isolated fake-driven development
+        # so that we get nice isolated fake-driven development
         !service_enabled_in_env?(default: false)
       else
         # in any production-like environment, default to all services enabled

--- a/lib/webvalve/fake_service_config.rb
+++ b/lib/webvalve/fake_service_config.rb
@@ -49,8 +49,8 @@ module WebValve
     end
 
     def service_enabled_in_env?(default:)
-      value = ENV.fetch("#{service_name.to_s.upcase}_ENABLED", default).to_s
-      WebValve::ENABLED_VALUES.include?(value)
+      value = ENV.fetch("#{service_name.to_s.upcase}_ENABLED", default)
+      WebValve::ENABLED_VALUES.include?(value.to_s)
     end
 
     def default_service_url

--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -27,7 +27,7 @@ module WebValve
 
       if intercepting?
         fake_service_configs.each do |config|
-          if WebValve.env.test? || config.explicitly_enabled?
+          if !WebValve.env.test? && config.explicitly_enabled?
             allowlist_service config
           else
             webmock_service config
@@ -48,6 +48,16 @@ module WebValve
           WebMock.enable!
         end
       end
+    end
+
+    # @api private
+    def intercepting?
+      in_always_intercepting_env? || ENABLED_VALUES.include?(ENV['WEBVALVE_ENABLED'])
+    end
+
+    # @api private
+    def allowing?
+      !in_always_intercepting_env? && DISABLED_VALUES.include?(ENV['WEBVALVE_ENABLED'])
     end
 
     # @api private

--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -34,6 +34,7 @@ module WebValve
           end
         end
         WebMock.disable_net_connect! webmock_disable_options
+        WebMock.enable!
       end
 
       if allowing?
@@ -42,10 +43,11 @@ module WebValve
             webmock_service config
           end
         end
-        WebMock.allow_net_connect!
+        if fake_service_configs.any?(&:explicitly_disabled?)
+          WebMock.allow_net_connect!
+          WebMock.enable!
+        end
       end
-
-      WebMock.enable!
     end
 
     # @api private

--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -51,6 +51,11 @@ module WebValve
     end
 
     # @api private
+    def disabled?
+      !intercepting? && !allowing?
+    end
+
+    # @api private
     def intercepting?
       in_always_intercepting_env? || ENABLED_VALUES.include?(ENV['WEBVALVE_ENABLED'])
     end
@@ -78,22 +83,10 @@ module WebValve
 
     private
 
-    def disabled?
-      !intercepting? && !allowing?
-    end
-
-    def intercepting?
-      in_always_intercepting_env? || ENABLED_VALUES.include?(ENV['WEBVALVE_ENABLED'])
-    end
-
-    def allowing?
-      !in_always_intercepting_env? && DISABLED_VALUES.include?(ENV['WEBVALVE_ENABLED'])
-    end
-
     def in_always_intercepting_env?
       if WebValve.env.in?(ALWAYS_ENABLED_ENVS)
         if ENV.key? 'WEBVALVE_ENABLED'
-          logger.warn(<<~MESSAGE)
+          WebValve.logger.warn(<<~MESSAGE)
             WARNING: Ignoring WEBVALVE_ENABLED environment variable setting (#{ENV['WEBVALVE_ENABLED']})
             WebValve is always enabled in development and test environments.
           MESSAGE

--- a/lib/webvalve/railtie.rb
+++ b/lib/webvalve/railtie.rb
@@ -1,7 +1,7 @@
 module WebValve
   class Railtie < ::Rails::Railtie
     initializer 'webvalve.set_autoload_paths', before: :set_autoload_paths do |app|
-      if WebValve.enabled?
+      unless WebValve.disabled?
         WebValve.config_paths << app.root
 
         WebValve.config_paths.each do |root|
@@ -11,7 +11,7 @@ module WebValve
     end
 
     initializer 'webvalve.setup', after: :load_config_initializers do
-      if WebValve.enabled?
+      unless WebValve.disabled?
         WebValve.config_paths.each do |root|
           path = root.join('config', 'webvalve.rb').to_s
           load path if File.exist?(path)

--- a/lib/webvalve/railtie.rb
+++ b/lib/webvalve/railtie.rb
@@ -1,7 +1,7 @@
 module WebValve
   class Railtie < ::Rails::Railtie
     initializer 'webvalve.set_autoload_paths', before: :set_autoload_paths do |app|
-      unless WebValve.disabled?
+      if WebValve.enabled?
         WebValve.config_paths << app.root
 
         WebValve.config_paths.each do |root|
@@ -11,7 +11,7 @@ module WebValve
     end
 
     initializer 'webvalve.setup', after: :load_config_initializers do
-      unless WebValve.disabled?
+      if WebValve.enabled?
         WebValve.config_paths.each do |root|
           path = root.join('config', 'webvalve.rb').to_s
           load path if File.exist?(path)

--- a/lib/webvalve/version.rb
+++ b/lib/webvalve/version.rb
@@ -1,3 +1,3 @@
 module WebValve
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/spec/webvalve/fake_service_config_spec.rb
+++ b/spec/webvalve/fake_service_config_spec.rb
@@ -19,114 +19,50 @@ RSpec.describe WebValve::FakeServiceConfig do
 
   subject { described_class.new service_class_name: fake_service.name }
 
-  describe '.should_intercept?' do
-    context 'in test env' do
-      around do |ex|
-        with_rails_env 'test' do
-          ex.run
-        end
-      end
-
-      it 'returns true when DUMMY_ENABLED is unset' do
-        expect(subject.should_intercept?).to eq true
-      end
-
-      it 'returns true regardless of DUMMY_ENABLED value' do
-        with_env 'DUMMY_ENABLED' => '1' do
-          expect(subject.should_intercept?).to eq true
-        end
-
-        with_env 'DUMMY_ENABLED' => '0' do
-          expect(subject.should_intercept?).to eq true
-        end
-      end
+  describe '.explicitly_enabled?' do
+    it 'returns false when DUMMY_ENABLED is unset' do
+      expect(subject.explicitly_enabled?).to eq false
     end
 
-    context 'in development env' do
-      around do |ex|
-        with_rails_env 'development' do
-          ex.run
-        end
+    it 'returns true when DUMMY_ENABLED is truthy' do
+      with_env 'DUMMY_ENABLED' => '1' do
+        expect(subject.explicitly_enabled?).to eq true
       end
 
-      it 'returns true when DUMMY_ENABLED is unset' do
-        expect(subject.should_intercept?).to eq true
+      with_env 'DUMMY_ENABLED' => 't' do
+        expect(subject.explicitly_enabled?).to eq true
       end
 
-      it 'returns false when DUMMY_ENABLED is truthy' do
-        with_env 'DUMMY_ENABLED' => '1' do
-          expect(subject.should_intercept?).to eq false
-        end
-
-        with_env 'DUMMY_ENABLED' => 't' do
-          expect(subject.should_intercept?).to eq false
-        end
-
-        with_env 'DUMMY_ENABLED' => 'true' do
-          expect(subject.should_intercept?).to eq false
-        end
+      with_env 'DUMMY_ENABLED' => 'true' do
+        expect(subject.explicitly_enabled?).to eq true
       end
 
-      it 'returns true when DUMMY_ENABLED is not truthy' do
-        with_env 'DUMMY_ENABLED' => '0' do
-          expect(subject.should_intercept?).to eq true
-        end
-
-        with_env 'DUMMY_ENABLED' => 'f' do
-          expect(subject.should_intercept?).to eq true
-        end
-
-        with_env 'DUMMY_ENABLED' => 'false' do
-          expect(subject.should_intercept?).to eq true
-        end
-
-        with_env 'DUMMY_ENABLED' => 'not true or false' do
-          expect(subject.should_intercept?).to eq true
-        end
+      with_env 'DUMMY_ENABLED' => 'not true or false' do
+        expect(subject.explicitly_enabled?).to eq false
       end
     end
+  end
 
-    context 'in production enviroment' do
-      around do |ex|
-        with_rails_env 'production' do
-          ex.run
-        end
+  describe '.explicitly_disabled?' do
+    it 'returns false when DUMMY_ENABLED is unset' do
+      expect(subject.explicitly_disabled?).to eq false
+    end
+
+    it 'returns true when DUMMY_ENABLED is falsey' do
+      with_env 'DUMMY_ENABLED' => '0' do
+        expect(subject.explicitly_disabled?).to eq true
       end
 
-      it 'returns false' do
-        expect(subject.should_intercept?).to eq false
+      with_env 'DUMMY_ENABLED' => 'f' do
+        expect(subject.explicitly_disabled?).to eq true
       end
 
-      it 'returns false regardless of DUMMY_ENABLED value' do
-        with_env 'DUMMY_ENABLED' => '1' do
-          expect(subject.should_intercept?).to eq false
-        end
-
-        with_env 'DUMMY_ENABLED' => '0' do
-          expect(subject.should_intercept?).to eq false
-        end
+      with_env 'DUMMY_ENABLED' => 'false' do
+        expect(subject.explicitly_disabled?).to eq true
       end
 
-      context 'when WEBVALVE_ENABLED is true' do
-        around do |ex|
-          with_env 'WEBVALVE_ENABLED' => '1' do
-            ex.run
-          end
-        end
-
-        it 'returns returns false when DUMMY_ENABLED is unset' do
-          expect(subject.should_intercept?).to eq false
-        end
-
-        it 'respects DUMMY_ENABLED flag' do
-          with_env 'DUMMY_ENABLED' => '1' do
-            expect(subject.should_intercept?).to eq false
-          end
-
-          with_env 'DUMMY_ENABLED' => '0' do
-            expect(subject.should_intercept?).to eq true
-          end
-        end
+      with_env 'DUMMY_ENABLED' => 'not true or false' do
+        expect(subject.explicitly_disabled?).to eq false
       end
     end
   end

--- a/spec/webvalve/fake_service_config_spec.rb
+++ b/spec/webvalve/fake_service_config_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe WebValve::FakeServiceConfig do
           end
         end
 
-        it 'still returns false by default' do
+        it 'returns returns false when DUMMY_ENABLED is unset' do
           expect(subject.should_intercept?).to eq false
         end
 

--- a/spec/webvalve/fake_service_config_spec.rb
+++ b/spec/webvalve/fake_service_config_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe WebValve::FakeServiceConfig do
           end
         end
 
-        it 'returns true' do
-          expect(subject.should_intercept?).to eq true
+        it 'still returns false by default' do
+          expect(subject.should_intercept?).to eq false
         end
 
         it 'respects DUMMY_ENABLED flag' do

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WebValve::Manager do
     context 'when WebValve is on and intercepting traffic' do
       around do |ex|
         with_rails_env 'production' do
-          with_env 'WEBVALVE_ENABLED' => '1' do
+          with_env 'WEBVALVE_ENABLED' => '1', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => '0' do
             ex.run
           end
         end
@@ -134,7 +134,7 @@ RSpec.describe WebValve::Manager do
     context 'when WebValve is on and allowing traffic' do
       around do |ex|
         with_rails_env 'production' do
-          with_env 'WEBVALVE_ENABLED' => '0' do
+          with_env 'WEBVALVE_ENABLED' => '1', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => '1' do
             ex.run
           end
         end
@@ -314,17 +314,45 @@ RSpec.describe WebValve::Manager do
         end
       end
 
-      it 'returns true when WEBVALVE_ENABLED is truthy' do
-        with_env 'WEBVALVE_ENABLED' => '1' do
+      it 'returns true when WEBVALVE_ENABLED is truthy and WEBVALVE_SERVICE_ENABLED_DEFAULT is set and falsey' do
+        with_env 'WEBVALVE_ENABLED' => '1', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => '0' do
           expect(subject.intercepting?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 't', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 'f' do
+          expect(subject.intercepting?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'true', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 'false' do
+          expect(subject.intercepting?).to eq true
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is truthy and WEBVALVE_SERVICE_ENABLED_DEFAULT is set and truthy' do
+        with_env 'WEBVALVE_ENABLED' => '1', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => '1' do
+          expect(subject.intercepting?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 't', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 't' do
+          expect(subject.intercepting?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'true', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 'true' do
+          expect(subject.intercepting?).to eq false
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is truthy but WEBVALVE_SERVICE_ENABLED_DEFAULT is unset' do
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.intercepting?).to eq false
         end
 
         with_env 'WEBVALVE_ENABLED' => 't' do
-          expect(subject.intercepting?).to eq true
+          expect(subject.intercepting?).to eq false
         end
 
         with_env 'WEBVALVE_ENABLED' => 'true' do
-          expect(subject.intercepting?).to eq true
+          expect(subject.intercepting?).to eq false
         end
       end
 
@@ -414,38 +442,65 @@ RSpec.describe WebValve::Manager do
         end
       end
 
-      it 'return true when WEBVALVE_ENABLED is unset' do
+      it 'returns false when WEBVALVE_ENABLED is unset' do
         with_env 'WEBVALVE_ENABLED' => nil do
-          # FIXME: if we remove disabled? then this should be true
           expect(subject.allowing?).to eq false
         end
       end
 
 
-      it 'returns true when WEBVALVE_ENABLED is falsey' do
-        with_env 'WEBVALVE_ENABLED' => '0' do
-          expect(subject.allowing?).to eq true
-        end
-
-        with_env 'WEBVALVE_ENABLED' => 'f' do
-          expect(subject.allowing?).to eq true
-        end
-
-        with_env 'WEBVALVE_ENABLED' => 'false' do
-          expect(subject.allowing?).to eq true
-        end
-      end
-
-      it 'returns false when WEBVALVE_ENABLED is truthy' do
+      it 'returns true when WEBVALVE_ENABLED is truthy and WEBVALVE_SERVICE_ENABLED_DEFAULT is unset' do
         with_env 'WEBVALVE_ENABLED' => '1' do
-          expect(subject.allowing?).to eq false
+          expect(subject.allowing?).to eq true
         end
 
         with_env 'WEBVALVE_ENABLED' => 't' do
-          expect(subject.allowing?).to eq false
+          expect(subject.allowing?).to eq true
         end
 
         with_env 'WEBVALVE_ENABLED' => 'true' do
+          expect(subject.allowing?).to eq true
+        end
+      end
+
+      it 'returns true when WEBVALVE_ENABLED is truthy and WEBVALVE_SERVICE_ENABLED_DEFAULT is truthy' do
+        with_env 'WEBVALVE_ENABLED' => '1', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => '1' do
+          expect(subject.allowing?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 't', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 't' do
+          expect(subject.allowing?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'true', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 'true' do
+          expect(subject.allowing?).to eq true
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is truthy and WEBVALVE_SERVICE_ENABLED_DEFAULT is set and falsey' do
+        with_env 'WEBVALVE_ENABLED' => '1', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => '0' do
+          expect(subject.allowing?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 't', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 'f' do
+          expect(subject.allowing?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'true', 'WEBVALVE_SERVICE_ENABLED_DEFAULT' => 'false' do
+          expect(subject.allowing?).to eq false
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is falsey' do
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.allowing?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'f' do
+          expect(subject.allowing?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'false' do
           expect(subject.allowing?).to eq false
         end
 
@@ -456,7 +511,7 @@ RSpec.describe WebValve::Manager do
     end
   end
 
-  describe '.disabled?' do
+  describe '.enabled?' do
     context 'in test env' do
       around do |ex|
         with_rails_env 'test' do
@@ -464,22 +519,22 @@ RSpec.describe WebValve::Manager do
         end
       end
 
-      it 'returns false when WEBVALVE_ENABLED is unset' do
+      it 'returns true when WEBVALVE_ENABLED is unset' do
         with_env 'WEBVALVE_ENABLED' => nil do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
         end
       end
 
-      it 'returns false regardless of WEBVALVE_ENABLED value' do
+      it 'returns true regardless of WEBVALVE_ENABLED value' do
         allow(WebValve.logger).to receive(:warn)
 
         with_env 'WEBVALVE_ENABLED' => '1' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
           expect(WebValve.logger).to have_received(:warn).at_least(1)
         end
 
         with_env 'WEBVALVE_ENABLED' => '0' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
           expect(WebValve.logger).to have_received(:warn).at_least(1)
         end
       end
@@ -492,22 +547,22 @@ RSpec.describe WebValve::Manager do
         end
       end
 
-      it 'returns false when WEBVALVE_ENABLED is unset' do
+      it 'returns true when WEBVALVE_ENABLED is unset' do
         with_env 'WEBVALVE_ENABLED' => nil do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
         end
       end
 
-      it 'returns false regardless of WEBVALVE_ENABLED value' do
+      it 'returns true regardless of WEBVALVE_ENABLED value' do
         allow(WebValve.logger).to receive(:warn)
 
         with_env 'WEBVALVE_ENABLED' => '1' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
           expect(WebValve.logger).to have_received(:warn).at_least(1)
         end
 
         with_env 'WEBVALVE_ENABLED' => '0' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
           expect(WebValve.logger).to have_received(:warn).at_least(1)
         end
       end
@@ -520,44 +575,44 @@ RSpec.describe WebValve::Manager do
         end
       end
 
-      it 'returns true when WEBVALVE_ENABLED is unset' do
+      it 'returns false when WEBVALVE_ENABLED is unset' do
         with_env 'WEBVALVE_ENABLED' => nil do
-          expect(subject.disabled?).to eq true
+          expect(subject.enabled?).to eq false
         end
       end
 
 
       it 'returns false when WEBVALVE_ENABLED is falsey' do
         with_env 'WEBVALVE_ENABLED' => '0' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq false
         end
 
         with_env 'WEBVALVE_ENABLED' => 'f' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq false
         end
 
         with_env 'WEBVALVE_ENABLED' => 'false' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq false
         end
       end
 
-      it 'returns false when WEBVALVE_ENABLED is truthy' do
+      it 'returns true when WEBVALVE_ENABLED is truthy' do
         with_env 'WEBVALVE_ENABLED' => '1' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
         end
 
         with_env 'WEBVALVE_ENABLED' => 't' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
         end
 
         with_env 'WEBVALVE_ENABLED' => 'true' do
-          expect(subject.disabled?).to eq false
+          expect(subject.enabled?).to eq true
         end
       end
 
-      it 'returns true when WEBVALVE_ENABLED is an invalid value' do
+      it 'returns false when WEBVALVE_ENABLED is an invalid value' do
         with_env 'WEBVALVE_ENABLED' => 'not true or false' do
-          expect(subject.disabled?).to eq true
+          expect(subject.enabled?).to eq false
         end
       end
     end

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -455,4 +455,111 @@ RSpec.describe WebValve::Manager do
       end
     end
   end
+
+  describe '.disabled?' do
+    context 'in test env' do
+      around do |ex|
+        with_rails_env 'test' do
+          ex.run
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is unset' do
+        with_env 'WEBVALVE_ENABLED' => nil do
+          expect(subject.disabled?).to eq false
+        end
+      end
+
+      it 'returns false regardless of WEBVALVE_ENABLED value' do
+        allow(WebValve.logger).to receive(:warn)
+
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.disabled?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.disabled?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+      end
+    end
+
+    context 'in development env' do
+      around do |ex|
+        with_rails_env 'development' do
+          ex.run
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is unset' do
+        with_env 'WEBVALVE_ENABLED' => nil do
+          expect(subject.disabled?).to eq false
+        end
+      end
+
+      it 'returns false regardless of WEBVALVE_ENABLED value' do
+        allow(WebValve.logger).to receive(:warn)
+
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.disabled?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.disabled?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+      end
+    end
+
+    context 'in production enviroment' do
+      around do |ex|
+        with_rails_env 'production' do
+          ex.run
+        end
+      end
+
+      it 'returns true when WEBVALVE_ENABLED is unset' do
+        with_env 'WEBVALVE_ENABLED' => nil do
+          expect(subject.disabled?).to eq true
+        end
+      end
+
+
+      it 'returns false when WEBVALVE_ENABLED is falsey' do
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.disabled?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'f' do
+          expect(subject.disabled?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'false' do
+          expect(subject.disabled?).to eq false
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is truthy' do
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.disabled?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 't' do
+          expect(subject.disabled?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'true' do
+          expect(subject.disabled?).to eq false
+        end
+      end
+
+      it 'returns true when WEBVALVE_ENABLED is an invalid value' do
+        with_env 'WEBVALVE_ENABLED' => 'not true or false' do
+          expect(subject.disabled?).to eq true
+        end
+      end
+    end
+  end
 end

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -32,34 +32,171 @@ RSpec.describe WebValve::Manager do
     it 'stores the url' do
       fake = class_double(WebValve::FakeService, name: "FooService")
 
-      subject.register fake.name, url: 'http://manual.dev'
-      expect(subject.fake_service_configs.first.service_url).to eq 'http://manual.dev'
+      subject.register fake.name, url: 'http://foo.dev'
+      expect(subject.fake_service_configs.first.service_url).to eq 'http://foo.dev'
     end
   end
 
   describe '#setup' do
-    it 'enables webmock' do
-      allow(WebMock).to receive(:enable!)
+    context 'when WebValve is disabled' do
+      around do |ex|
+        with_rails_env 'production' do
+          # unset
+          with_env 'WEBVALVE_ENABLED' => nil do
+            ex.run
+          end
+        end
+      end
 
-      subject.setup
+      it 'does not setup webmock' do
+        allow(WebMock).to receive(:allow_net_connect!)
+        allow(WebMock).to receive(:enable!)
 
-      expect(WebMock).to have_received(:enable!)
+        subject.setup
+
+        expect(WebMock).not_to have_received(:allow_net_connect!)
+        expect(WebMock).not_to have_received(:enable!)
+      end
     end
 
-    it 'disables network connections' do
-      allow(WebMock).to receive(:disable_net_connect!)
+    context 'when WebValve is on and intercepting traffic' do
+      around do |ex|
+        with_rails_env 'production' do
+          with_env 'WEBVALVE_ENABLED' => '1' do
+            ex.run
+          end
+        end
+      end
 
-      subject.setup
+      it 'enables webmock' do
+        allow(WebMock).to receive(:enable!)
 
-      expect(WebMock).to have_received(:disable_net_connect!)
+        subject.setup
+
+        expect(WebMock).to have_received(:enable!)
+      end
+
+      it 'disables network connections' do
+        allow(WebMock).to receive(:disable_net_connect!)
+
+        subject.setup
+
+        expect(WebMock).to have_received(:disable_net_connect!)
+      end
+
+      it 'allows localhost connections' do
+        allow(WebMock).to receive(:disable_net_connect!)
+
+        subject.setup
+
+        expect(WebMock).to have_received(:disable_net_connect!).with(hash_including(allow_localhost: true))
+      end
+
+      it 'allowlists configured urls in webmock' do
+        allow(WebMock).to receive(:disable_net_connect!)
+        results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
+
+        subject.allow_url 'http://foo.dev'
+        subject.allow_url 'http://bar.dev'
+
+        subject.setup
+
+        expect(WebMock).to have_received(:disable_net_connect!)
+          .with(hash_including(allow: results))
+      end
+
+      it 'mocks registered fakes that are not enabled in ENV' do
+        disabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
+        web_mock_stubble = double(to_rack: true)
+        allow(WebMock).to receive(:stub_request).and_return(web_mock_stubble)
+
+        with_env 'SOMETHING_API_URL' => 'http://something.dev' do
+          subject.register disabled_service.name
+          subject.setup
+        end
+
+        expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://something\.dev})
+        expect(web_mock_stubble).to have_received(:to_rack)
+      end
+
+      it 'allowlists registered fakes that are enabled in ENV' do
+        enabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
+
+        with_env 'SOMETHING_ENABLED' => '1', 'SOMETHING_API_URL' => 'http://something.dev' do
+          subject.register enabled_service.name
+          subject.setup
+        end
+
+        expect(subject.allowlisted_urls).to include 'http://something.dev'
+      end
     end
 
-    it 'allows localhost connections' do
-      allow(WebMock).to receive(:disable_net_connect!)
+    context 'when WebValve is on and allowing traffic' do
+      around do |ex|
+        with_rails_env 'production' do
+          with_env 'WEBVALVE_ENABLED' => '0' do
+            ex.run
+          end
+        end
+      end
 
-      subject.setup
+      context 'when there are no services disabled' do
+        it 'does not setup webmock' do
+          allow(WebMock).to receive(:allow_net_connect!)
+          allow(WebMock).to receive(:enable!)
 
-      expect(WebMock).to have_received(:disable_net_connect!).with(hash_including(allow_localhost: true))
+          subject.setup
+
+          expect(WebMock).not_to have_received(:allow_net_connect!)
+          expect(WebMock).not_to have_received(:enable!)
+        end
+      end
+
+      context 'when there are explicitly disabled fake services to stub' do
+        it 'allows network connections and enables webmock' do
+          allow(WebMock).to receive(:allow_net_connect!)
+          allow(WebMock).to receive(:enable!)
+
+          enabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
+
+          with_env 'SOMETHING_ENABLED' => '0', 'SOMETHING_API_URL' => 'http://something.dev' do
+            subject.register enabled_service.name
+            subject.setup
+          end
+
+          expect(WebMock).to have_received(:allow_net_connect!)
+          expect(WebMock).to have_received(:enable!)
+        end
+
+        it 'mocks registered fakes that are explicitly disabled in ENV' do
+          disabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
+          other_service = class_double(WebValve::FakeService, name: 'FakeOther')
+
+          web_mock_stubble = double(to_rack: true)
+          allow(WebMock).to receive(:stub_request).and_return(web_mock_stubble)
+
+          with_env 'SOMETHING_API_URL' => 'http://something.dev', 'SOMETHING_ENABLED' => '0', 'OTHER_API_URL' => 'http://other.dev' do
+            subject.register disabled_service.name
+            subject.register other_service.name
+            subject.setup
+          end
+
+          expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://something\.dev})
+          expect(WebMock).not_to have_received(:stub_request).with(:any, %r{\Ahttp://other\.dev})
+          expect(web_mock_stubble).to have_received(:to_rack).once
+        end
+
+        it 'does not allowlist registered fakes because the network is enabled' do
+          some_service = class_double(WebValve::FakeService, name: 'FakeSomething')
+
+          with_env 'SOMETHING_API_URL' => 'http://something.dev' do
+            subject.register some_service.name
+            subject.setup
+          end
+
+          expect(subject.allowlisted_urls).not_to include 'http://something.dev'
+        end
+      end
     end
 
     context 'in test environment' do
@@ -81,51 +218,26 @@ RSpec.describe WebValve::Manager do
         expect(WebMock).not_to have_received(:disable_net_connect!)
           .with(hash_including(allow: results))
       end
-    end
 
-    context 'in non-test environment' do
-      around do |example|
-        with_rails_env 'development' do
-          example.run
-        end
-      end
+      it 'fakes all services regardless of ENV settings' do
+        enabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
+        disabled_service = class_double(WebValve::FakeService, name: 'FakeSomethingElse')
+        other_service = class_double(WebValve::FakeService, name: 'FakeOther')
 
-      it 'allowlists configured urls in webmock' do
-        allow(WebMock).to receive(:disable_net_connect!)
-        results = [%r{\Ahttp://foo\.dev}, %r{\Ahttp://bar\.dev}]
-
-        subject.allow_url 'http://foo.dev'
-        subject.allow_url 'http://bar.dev'
-
-        subject.setup
-
-        expect(WebMock).to have_received(:disable_net_connect!)
-          .with(hash_including(allow: results))
-      end
-
-      it 'mocks registered fakes that are not enabled in ENV' do
-        disabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
         web_mock_stubble = double(to_rack: true)
         allow(WebMock).to receive(:stub_request).and_return(web_mock_stubble)
 
-        with_env 'SOMETHING_API_URL' => 'http://fake.dev' do
-          subject.register disabled_service.name
+        with_env 'SOMETHING_ENABLED' => '1', 'SOMETHING_ELSE_ENABLED' => '0', 'OTHER_ENABLED' => nil do
+          subject.register disabled_service.name, url: 'http://something.dev'
+          subject.register enabled_service.name, url: 'http://something-else.dev'
+          subject.register other_service.name, url: 'http://other.dev'
           subject.setup
         end
 
-        expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://fake\.dev})
-        expect(web_mock_stubble).to have_received(:to_rack)
-      end
-
-      it 'allowlists registered fakes that are enabled in ENV' do
-        enabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
-
-        with_env 'SOMETHING_ENABLED' => '1', 'SOMETHING_API_URL' => 'http://real.dev' do
-          subject.register enabled_service.name
-          subject.setup
-        end
-
-        expect(subject.allowlisted_urls).to include 'http://real.dev'
+        expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://something\.dev})
+        expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://something\-else\.dev})
+        expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://other\.dev})
+        expect(web_mock_stubble).to have_received(:to_rack).exactly(3).times
       end
     end
   end

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -241,4 +241,218 @@ RSpec.describe WebValve::Manager do
       end
     end
   end
+
+  describe '.intercepting?' do
+    context 'in test env' do
+      around do |ex|
+        with_rails_env 'test' do
+          ex.run
+        end
+      end
+
+      it 'returns true when WEBVALVE_ENABLED is unset' do
+        expect(subject.intercepting?).to eq true
+      end
+
+      it 'returns true regardless of WEBVALVE_ENABLED value' do
+        allow(WebValve.logger).to receive(:warn)
+
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.intercepting?).to eq true
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.intercepting?).to eq true
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+      end
+    end
+
+    context 'in development env' do
+      around do |ex|
+        with_rails_env 'development' do
+          ex.run
+        end
+      end
+
+      it 'returns true when WEBVALVE_ENABLED is unset' do
+        expect(subject.intercepting?).to eq true
+      end
+
+      it 'returns true regardless of WEBVALVE_ENABLED value' do
+        allow(WebValve.logger).to receive(:warn)
+
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.intercepting?).to eq true
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.intercepting?).to eq true
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+      end
+
+      it 'returns true when WEBVALVE_ENABLED is unset' do
+        with_env 'WEBVALVE_ENABLED' => nil do
+          expect(subject.intercepting?).to eq true
+        end
+      end
+    end
+
+    context 'in production enviroment' do
+      around do |ex|
+        with_rails_env 'production' do
+          ex.run
+        end
+      end
+
+      it 'return false when WEBVALVE_ENABLED is unset' do
+        with_env 'WEBVALVE_ENABLED' => nil do
+          expect(subject.intercepting?).to eq false
+        end
+      end
+
+      it 'returns true when WEBVALVE_ENABLED is truthy' do
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.intercepting?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 't' do
+          expect(subject.intercepting?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'true' do
+          expect(subject.intercepting?).to eq true
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is not truthy' do
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.intercepting?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'f' do
+          expect(subject.intercepting?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'false' do
+          expect(subject.intercepting?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'not true or false' do
+          expect(subject.intercepting?).to eq false
+        end
+      end
+    end
+  end
+
+  describe '.allowing?' do
+    context 'in test env' do
+      around do |ex|
+        with_rails_env 'test' do
+          ex.run
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is unset' do
+        expect(subject.allowing?).to eq false
+      end
+
+      it 'returns false regardless of WEBVALVE_ENABLED value' do
+        allow(WebValve.logger).to receive(:warn)
+
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.allowing?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.allowing?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+      end
+    end
+
+    context 'in development env' do
+      around do |ex|
+        with_rails_env 'development' do
+          ex.run
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is unset' do
+        expect(subject.allowing?).to eq false
+      end
+
+      it 'returns false regardless of WEBVALVE_ENABLED value' do
+        allow(WebValve.logger).to receive(:warn)
+
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.allowing?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.allowing?).to eq false
+          expect(WebValve.logger).to have_received(:warn).at_least(1)
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is unset' do
+        with_env 'WEBVALVE_ENABLED' => nil do
+          expect(subject.allowing?).to eq false
+        end
+      end
+    end
+
+    context 'in production enviroment' do
+      around do |ex|
+        with_rails_env 'production' do
+          ex.run
+        end
+      end
+
+      it 'return true when WEBVALVE_ENABLED is unset' do
+        with_env 'WEBVALVE_ENABLED' => nil do
+          # FIXME: if we remove disabled? then this should be true
+          expect(subject.allowing?).to eq false
+        end
+      end
+
+
+      it 'returns true when WEBVALVE_ENABLED is falsey' do
+        with_env 'WEBVALVE_ENABLED' => '0' do
+          expect(subject.allowing?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'f' do
+          expect(subject.allowing?).to eq true
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'false' do
+          expect(subject.allowing?).to eq true
+        end
+      end
+
+      it 'returns false when WEBVALVE_ENABLED is truthy' do
+        with_env 'WEBVALVE_ENABLED' => '1' do
+          expect(subject.allowing?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 't' do
+          expect(subject.allowing?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'true' do
+          expect(subject.allowing?).to eq false
+        end
+
+        with_env 'WEBVALVE_ENABLED' => 'not true or false' do
+          expect(subject.allowing?).to eq false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
this changeset makes it so that webvalve has the following behavior:

when the env is test/development
* webvalve is enabled and always runs in intercepting mode where
  services are intercepted by default

when the env is NOT test/development, e.g. production
* webvalve is disabled unless WEBVALVE_ENABLED=1/t/true
* when WEBVALVE_ENABLED is truthy, webvalve is enabled in allowing mode
  where all traffic is allowed by default
* $SERVICE_ENABLED=0/f/false can be used to switch a service into intercepting
  mode, i.e. enable the fake service
* when WEBVALVE_ENABLED is truthy and
  WEBVALVE_SERVICE_ENABLED_DEFAULT=0/f/false then webvalve is enabled in
  intercepting mode where all traffic is intercepted by default
* $SERVICE_ENABLED=1/t/true can be used to switch a service into
  allowing mode, i.e. allow the traffic to that service to go through to
  the internet

/domain @smudge @jmileham @klesse413 @effron
/no-platform