### PR TITLE
Raise error for duplicate stubbed urls

### DIFF
--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -69,6 +69,7 @@ module WebValve
     def reset
       allowlisted_urls.clear
       fake_service_configs.clear
+      stubbed_urls.clear
     end
 
     # @api private
@@ -126,6 +127,8 @@ module WebValve
     end
 
     def webmock_service(config)
+      ensure_non_duplicate_stub(config)
+
       WebMock.stub_request(
         :any,
         url_to_regexp(config.service_url)
@@ -138,6 +141,15 @@ module WebValve
 
     def url_to_regexp(url)
       %r(\A#{Regexp.escape url})
+    end
+
+    def ensure_non_duplicate_stub(config)
+      raise "Invalid config for #{config.service_class_name}. Already stubbed url #{config.service_url}" if stubbed_urls.include?(config.service_url)
+      stubbed_urls << config.service_url
+    end
+
+    def stubbed_urls
+      @stubbed_urls ||= Set.new
     end
   end
 end

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -129,6 +129,18 @@ RSpec.describe WebValve::Manager do
 
         expect(subject.allowlisted_urls).to include 'http://something.dev'
       end
+
+      it 'raises with duplicate stubbed urls' do
+        disabled_service = class_double(WebValve::FakeService, name: 'FakeSomething')
+        other_disabled_service = class_double(WebValve::FakeService, name: 'FakeOtherThing')
+
+        with_env 'SOMETHING_API_URL' => 'http://something.dev', 'OTHER_THING_API_URL' => 'http://something.dev' do
+          subject.register disabled_service.name
+          subject.register other_disabled_service.name
+
+          expect { subject.setup }.to raise_error('Invalid config for FakeOtherThing. Already stubbed url http://something.dev')
+        end
+      end
     end
 
     context 'when WebValve is on and allowing traffic' do


### PR DESCRIPTION
Closes https://github.com/Betterment/webvalve/issues/39

/domain @Betterment/webvalve-core
/no-platform

Raise an error if two different WebValve fake services are configured to intercept traffic for the same URL. Hopefully, this makes it easier to discover this kind of configuration bug.