### PR TITLE
Spec fix/workaround (in README and in webvalve/rspec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ RSpec.configure do |config|
   end
   
   config.around :each do |ex|
+    WebValve.reset
     WebValve.setup
     ex.run
   end

--- a/lib/webvalve/rspec.rb
+++ b/lib/webvalve/rspec.rb
@@ -3,6 +3,7 @@ require 'webmock/rspec'
 
 RSpec.configure do |c|
   c.around do |example|
+    WebValve.reset
     WebValve.setup
     example.run
   end

--- a/lib/webvalve/version.rb
+++ b/lib/webvalve/version.rb
@@ -1,3 +1,3 @@
 module WebValve
-  VERSION = "1.0.1"
+  VERSION = "1.0.0"
 end

--- a/lib/webvalve/version.rb
+++ b/lib/webvalve/version.rb
@@ -1,3 +1,3 @@
 module WebValve
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
/domain @Betterment/webvalve-core @samandmoore @effron 
/no-platform

It looks like #40 was merged but ~~never released until 1.0.0~~ [correction: it was released but we never pulled it into our app] -- I noticed a regression in our local app due to the way our tests had been configured:

```ruby
  config.around :each do |ex|
    WebValve.setup
    ex.run
  end
```

Unfortunately, "setup" now raises every time due to duplicate stubs.

This PR updates the rspec helper and the README to include the fix I made to the local app, but I'm wondering if this merits a slightly different API so that test-resets can be handled in a single command.

Maybe `WebValve.reset` should implicitly call `setup` again? And maybe we need a `WebValve.clear` that does what reset currently does and clears everything without setting up?

(Just brainstorming 🤔)