### PR TITLE
Allow same URLs when HTTP auth not the same

### DIFF
--- a/lib/webvalve/fake_service_config.rb
+++ b/lib/webvalve/fake_service_config.rb
@@ -15,11 +15,14 @@ module WebValve
       value_from_env.present? && WebValve::DISABLED_VALUES.include?(value_from_env.to_s)
     end
 
+    def full_url
+      @full_url ||= custom_service_url || default_service_url
+    end
+
     def service_url
       @service_url ||= begin
-        url = custom_service_url || default_service_url
-        raise missing_url_message if url.blank?
-        strip_basic_auth url
+        raise missing_url_message if full_url.blank?
+        strip_basic_auth full_url
       end
     end
 

--- a/lib/webvalve/manager.rb
+++ b/lib/webvalve/manager.rb
@@ -146,8 +146,8 @@ module WebValve
     end
 
     def ensure_non_duplicate_stub(config)
-      raise "Invalid config for #{config.service_class_name}. Already stubbed url #{config.service_url}" if stubbed_urls.include?(config.service_url)
-      stubbed_urls << config.service_url
+      raise "Invalid config for #{config.service_class_name}. Already stubbed url #{config.full_url}" if stubbed_urls.include?(config.full_url)
+      stubbed_urls << config.full_url
     end
 
     def load_configs!

--- a/spec/webvalve/manager_spec.rb
+++ b/spec/webvalve/manager_spec.rb
@@ -153,8 +153,7 @@ RSpec.describe WebValve::Manager do
           subject.register other_disabled_service.name
 
           expect { subject.setup }.to_not raise_error
-          expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://user1@something\.dev})
-          expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://user2@something\.dev})
+          expect(WebMock).to have_received(:stub_request).with(:any, %r{\Ahttp://something\.dev}).twice
         end
       end
     end


### PR DESCRIPTION
/domain @samandmoore @effron 
/no-platform

Uncovered another one! We have a case where we want to talk to the same service as two different users. The new `"Already stubbed url"` exception was blocking this use case because by the time we do the comparison we had already stripped the HTTP auth user/pw out of the URL.

This reworks that one check so that it uses the "full URL" (yeah wasn't sure what to call it) instead of the "service URL" (the one used in the mock, no HTTP auth included).