### PR TITLE
add a job that we can use for CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,8 @@ jobs:
           BUNDLE_GEMFILE: ${{ matrix.gemfile }}
         run: |
           bundle exec rake
+  ci-check:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0


### PR DESCRIPTION
okay! so the idea here is that if we add a new job `ci-check` that depends on all the `test` jobs being successful then we can configure the github branch protection rule settings to only require `ci-check` to be passing instead of having to continually change those settings based on the evolving matrix in the CI definition. 

i'm curious what folks think about this. cc @smudge 

@mbj didn't you have issues with this in some private repos because when a parent job is skipped it marks the child job as skipped and the branch protection rules consider skipped jobs as "good" for mergability? 