### PR TITLE
Replace File.exists? with File.exist for Ruby 3.2 compatibility

### DIFF
--- a/lib/generators/webvalve/fake_service_generator.rb
+++ b/lib/generators/webvalve/fake_service_generator.rb
@@ -43,7 +43,7 @@ module Webvalve
       end
 
       def require_config!
-        raise 'No WebValve configuration file found. Please run `rails generate webvalve:install` first' unless File.exists?(config_file_path)
+        raise 'No WebValve configuration file found. Please run `rails generate webvalve:install` first' unless File.exist?(config_file_path)
       end
 
       def config_file_path


### PR DESCRIPTION
Replace `File.exists?` with `File.exist?` due to removal of the former method in Ruby 3.2, ensuring compatibility with the latest Ruby versions



