### PR TITLE
Add host authorization config for sinatra 4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-linux
 

--- a/lib/webvalve/fake_service.rb
+++ b/lib/webvalve/fake_service.rb
@@ -8,6 +8,7 @@ module WebValve
     set :dump_errors, false
     set :show_exceptions, false
     set :raise_errors, true
+    set :host_authorization, ->() { {} }
 
     configure do
       use Instrumentation::Middleware


### PR DESCRIPTION
Sinatra 4.1.0 adds a new default config for permitted hosts (https://github.com/sinatra/sinatra/pull/2053). In the development environment, the permitted hosts are IP addresses, `.localhost`, and `.test`. This is causing failures in webvalve because webvalve passes through the original request, including the host of the faked service.

FWIW, I think this didn't get picked up by CI because #81 updated Gemfile.lock in the root directory, but it looks like CI runs against the Gemfiles in `gemfiles/*` which didn't get updated (so are still running against sinatra 4.0).