### PR TITLE
Fix broken LogSubscriber bolding

### DIFF
--- a/lib/webvalve/instrumentation/log_subscriber.rb
+++ b/lib/webvalve/instrumentation/log_subscriber.rb
@@ -11,7 +11,7 @@ module WebValve
         host = event.payload[:host]
         name = '%s %s (%.1fms)' % ["WebValve", "Request Captured", event.duration]
         details = "#{host} #{method} #{url} [#{status}]"
-        debug "  #{color(name, YELLOW, true)}  #{color(details, BOLD, true)}"
+        debug "  #{color(name, YELLOW, bold: true)}  #{color(details, BLACK, bold: true)}"
       end
     end
   end


### PR DESCRIPTION
Using Rails 8, LogSubscriber is currently producing errors:

```
2025-03-05 14:31:30.802151 E [70733:puma srv tp 004 log_subscriber.rb:188] Rails -- Could not log "request.webvalve" event. NameError: uninitialized constant WebValve::Instrumentation::LogSubscriber::BOLD ["/Users/aburgel/.asdf/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/webvalve-2.0.3/lib/webvalve/instrumentation/log_subscriber.rb:14:in 'WebValve::Instrumentation::LogSubscriber#request'",
```

Looks like `BOLD` was [removed in Rails 7.2](https://guides.rubyonrails.org/7_2_release_notes.html#active-support-removals).