### PR TITLE
chore: Pin Github Actions to Commit Hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           - gemfiles/ruby.gemfile
     name: Ruby ${{ matrix.ruby }}, ${{ matrix.gemfile }} Tests
     steps:
-      - uses: technote-space/auto-cancel-redundant-job@v1
+      - uses: technote-space/auto-cancel-redundant-job@7d35aba30420fc2368f8aeed50371e99e7fa3239 # v1
         if: github.event_name == 'pull_request'
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1
         env:
           BUNDLE_GEMFILE: ${{ matrix.gemfile }}
         with:


### PR DESCRIPTION
This PR includes automated changes from running [frizbee](https://github.com/stacklok/frizbee) to pin Github Actions. For more information on what this actually means, take a look at [our documentation on UnpinnedActions](https://github.com/betterment/claws?tab=readme-ov-file#unpinnedactions). Because `frizbee` will be replacing tags with their corresponding commit hash, this change should fundamentally be a no-op. This change just makes our code more explicit about what we're using.

Note that because we're touching Github Workflow files in this PR, there is a chance that [Claws](https://github.com/betterment/claws), our GHA Static Analyzer, will find other issues in those files that were introduced before this PR was created. These findings will need to be addressed before this PR can be merged. 

The Claws documentation has a good list for how to remediate each type of finding, but for brevity, here are some of the commonly seen ones:

* RiskyTriggers: Fires when a workflow has workflow_dispatch or pull_request_target; remediate by leaving comments explaning why, and put an ignore statement ([example](https://github.com/Betterment/retail/blob/92e76923f4e5d51e8386301538e383883cd5eb57/.github/workflows/create_datadog_slo.yml#L2-L4))
* UnsafeCheckout: Fires when a workflow checks out user supplied code; remediate by leaving a comment explaining how the user supplied code is used and confirm it isn't executed ([example](https://github.com/Betterment/linda-test/blob/6cd5954c7c1d2bdb781239b6686b3a5dcbcd6fda/.github/workflows/claws_fork_friendly.yml#L50-L54))

For other findings and how to remediate them, check the [Claws docs!](https://github.com/betterment/claws?tab=readme-ov-file#built-in-rules)

